### PR TITLE
Add Spring Actuator dependency to Keip

### DIFF
--- a/keip-container-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/keip-container-archetype/src/main/resources/archetype-resources/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>micrometer-tracing</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-kubernetes-client-config</artifactId>
         </dependency>

--- a/keip-default-image/pom.xml
+++ b/keip-default-image/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -12,7 +10,7 @@
     </parent>
 
     <groupId>com.octo.keip</groupId>
-    <artifactId>keip-integration</artifactId>
+    <artifactId>keip-default-image</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
     <properties>
@@ -53,6 +51,10 @@
             <artifactId>micrometer-tracing</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-kubernetes-client-config</artifactId>
         </dependency>
@@ -87,7 +89,7 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <container>
                         <creationTime>${maven.build.timestamp}</creationTime>

--- a/keip-default-image/src/main/java/com/octo/keip/KeipApplication.java
+++ b/keip-default-image/src/main/java/com/octo/keip/KeipApplication.java
@@ -1,4 +1,4 @@
-package com.octo.keip.container;
+package com.octo.keip;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,6 +1,6 @@
 # VERSION = 0.1.0
 
-KEIP_INTEGRATION_IMAGE ?= ghcr.io/octoconsulting/keip-integration:0.0.1-SNAPSHOT
+KEIP_INTEGRATION_IMAGE ?= ghcr.io/octoconsulting/keip-default-image:0.0.1-SNAPSHOT
 
 KUBECTL := kubectl
 KUBECTL_DELETE := $(KUBECTL) delete --ignore-not-found

--- a/operator/controller/integrationroute-controller.yaml
+++ b/operator/controller/integrationroute-controller.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: ghcr.io/octoconsulting/integration-route-lambda-controller:0.1.1
+          image: ghcr.io/octoconsulting/integration-route-lambda-controller:0.2.0
           ports:
             - containerPort: 7080
               name: webhook-http

--- a/operator/controller/webhook/Makefile
+++ b/operator/controller/webhook/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.1.1
+VERSION ?= 0.2.0
 HOST_PORT ?= 7080
 
 IMG_REGISTRY := ghcr.io/octoconsulting

--- a/operator/controller/webhook/introute/sync.py
+++ b/operator/controller/webhook/introute/sync.py
@@ -118,7 +118,21 @@ def _create_pod_template(parent, labels, integration_image):
                     "name": "integration-app",
                     "image": integration_image,
                     "volumeMounts": vol_config.get_mounts(),
-                }
+                    "livenessProbe": {
+                        "httpGet": {
+                            "path": "/actuator/health/liveness",
+                            "port": 8080,
+                        },
+                        "initialDelaySeconds": 10
+                    },
+                    "readinessProbe": {
+                        "httpGet": {
+                            "path": "/actuator/health/readiness",
+                            "port": 8080,
+                        },
+                        "initialDelaySeconds": 10
+                    },
+                },
             ],
             "volumes": vol_config.get_volumes(),
         },


### PR DESCRIPTION
## About
Adds the Acuator dependency and uses the default health endpoint for pod liveness and readiness probes.

## Testing
- `make build` in `.../operator/controller/webhook`
- `make all` in `.../operator`
- Deploy the example route: `kubectl apply -k .../operator/example`
- Once the route is healthy, verify there are no failures in the event log: `kubectl describe <route>`
- Optional: Verify you can curl the healthcheck endpoint by creating a service, port-forwarding it and executing `curl http://localhost:<nodeport>/actuator/health` against the exposed node port on your local machine. An example service.yml is provided below.

```yaml
---
apiVersion: v1
kind: Service
metadata:
  name: route
  namespace: default
spec:
  ports:
  - name: http
    port: 8080
    protocol: TCP
    targetPort: 8080
  selector:    
    app.kubernetes.io/instance: integrationroute-testroute
```