### PR TITLE
Bugfix: add spring web dependency for actuator to serve HTTP endpoints

### DIFF
--- a/keip-container-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/keip-container-archetype/src/main/resources/archetype-resources/pom.xml
@@ -46,6 +46,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>

--- a/keip-default-image/pom.xml
+++ b/keip-default-image/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.octo.keip</groupId>
     <artifactId>keip-default-image</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2</version>
 
     <properties>
         <docker.registry>ghcr.io/octoconsulting</docker.registry>
@@ -49,6 +49,10 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-tracing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,6 +1,6 @@
 # VERSION = 0.1.0
 
-KEIP_INTEGRATION_IMAGE ?= ghcr.io/octoconsulting/keip-default-image:0.0.1-SNAPSHOT
+KEIP_INTEGRATION_IMAGE ?= ghcr.io/octoconsulting/keip-default-image:0.0.2
 
 KUBECTL := kubectl
 KUBECTL_DELETE := $(KUBECTL) delete --ignore-not-found

--- a/operator/controller/webhook/test/json/full-response.json
+++ b/operator/controller/webhook/test/json/full-response.json
@@ -55,6 +55,20 @@
                     "mountPath": "/tmp/testdir"
                   }
                 ],
+                "livenessProbe": {
+                  "httpGet": {
+                    "path": "/actuator/health/liveness",
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 10
+                },
+                "readinessProbe": {
+                  "httpGet": {
+                    "path": "/actuator/health/readiness",
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 10
+                },
                 "env": [
                   {
                     "name": "SPRING_APPLICATION_JSON",


### PR DESCRIPTION
A dependency on spring-web is necessary to allow the actuator to serve healthcheck endoints over HTTP. Also, fix failing unit test.