### PR TITLE
Add a TLS trustore config to IntegrationRoute spec

### DIFF
--- a/operator/controller/integrationroute-controller.yaml
+++ b/operator/controller/integrationroute-controller.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: ghcr.io/octoconsulting/integration-route-lambda-controller:0.2.0
+          image: ghcr.io/octoconsulting/integration-route-lambda-controller:0.3.0
           ports:
             - containerPort: 7080
               name: webhook-http

--- a/operator/controller/webhook/Makefile
+++ b/operator/controller/webhook/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.2.0
+VERSION ?= 0.3.0
 HOST_PORT ?= 7080
 
 IMG_REGISTRY := ghcr.io/octoconsulting

--- a/operator/controller/webhook/README.md
+++ b/operator/controller/webhook/README.md
@@ -23,3 +23,8 @@ pip install -r requirements.txt
 
 You should now be able to use the `Makefile` for running tests or starting a dev server, among other
 tasks.
+
+#### Code Formatting
+
+To keep diffs small, consider using
+the [Black formatter](https://black.readthedocs.io/en/stable/integrations/editors.html).

--- a/operator/controller/webhook/test/json/full-iroute-request.json
+++ b/operator/controller/webhook/test/json/full-iroute-request.json
@@ -39,7 +39,11 @@
       "routeConfigMap": "testroute-xml",
       "secretSources": [
         "testroute-secret"
-      ]
+      ],
+      "tls": {
+        "configMapName": "test-tls-cm",
+        "key": "test-tls-key"
+      }
     }
   }
 }

--- a/operator/controller/webhook/test/json/full-iroute-request.json
+++ b/operator/controller/webhook/test/json/full-iroute-request.json
@@ -42,7 +42,8 @@
       ],
       "tls": {
         "configMapName": "test-tls-cm",
-        "key": "test-tls-key"
+        "key": "test-truststore.p12",
+        "type": "pkcs12"
       }
     }
   }

--- a/operator/controller/webhook/test/json/full-response.json
+++ b/operator/controller/webhook/test/json/full-response.json
@@ -53,6 +53,11 @@
                   {
                     "name": "testroute-pvc",
                     "mountPath": "/tmp/testdir"
+                  },
+                  {
+                    "name": "truststore",
+                    "readOnly": true,
+                    "mountPath": "/etc/cabundle"
                   }
                 ],
                 "livenessProbe": {
@@ -73,6 +78,10 @@
                   {
                     "name": "SPRING_APPLICATION_JSON",
                     "value": "{\"spring\": {\"config.import\": \"kubernetes:\", \"application\": {\"name\": \"testroute\"}, \"cloud\": {\"kubernetes\": {\"config\": {\"fail-fast\": true, \"namespace\": \"testspace\", \"sources\": [{\"name\": \"testroute-props\"}, {\"labels\": {\"group\": \"ir-common\"}}]}, \"secrets\": {\"paths\": \"/etc/secrets\"}}}}}"
+                  },
+                  {
+                    "name": "JDK_JAVA_OPTIONS",
+                    "value": "-Djavax.net.ssl.trustStore=/etc/cabundle/truststore.jks -Djavax.net.ssl.trustStorePassword=changeit"
                   }
                 ]
               }
@@ -94,6 +103,18 @@
                 "name": "testroute-pvc",
                 "persistentVolumeClaim": {
                   "claimName": "testroute-pvc"
+                }
+              },
+              {
+                "name": "truststore",
+                "configMap": {
+                  "name": "test-tls-cm",
+                  "items": [
+                    {
+                      "key": "test-tls-key",
+                      "path": "truststore.jks"
+                    }
+                  ]
                 }
               }
             ]

--- a/operator/controller/webhook/test/json/full-response.json
+++ b/operator/controller/webhook/test/json/full-response.json
@@ -77,11 +77,11 @@
                 "env": [
                   {
                     "name": "SPRING_APPLICATION_JSON",
-                    "value": "{\"spring\": {\"config.import\": \"kubernetes:\", \"application\": {\"name\": \"testroute\"}, \"cloud\": {\"kubernetes\": {\"config\": {\"fail-fast\": true, \"namespace\": \"testspace\", \"sources\": [{\"name\": \"testroute-props\"}, {\"labels\": {\"group\": \"ir-common\"}}]}, \"secrets\": {\"paths\": \"/etc/secrets\"}}}}}"
+                    "value": "{\"spring\": {\"application\": {\"name\": \"testroute\"}, \"config.import\": \"kubernetes:\", \"cloud\": {\"kubernetes\": {\"config\": {\"fail-fast\": true, \"namespace\": \"testspace\", \"sources\": [{\"name\": \"testroute-props\"}, {\"labels\": {\"group\": \"ir-common\"}}]}, \"secrets\": {\"paths\": \"/etc/secrets\"}}}}}"
                   },
                   {
                     "name": "JDK_JAVA_OPTIONS",
-                    "value": "-Djavax.net.ssl.trustStore=/etc/cabundle/truststore.jks -Djavax.net.ssl.trustStorePassword=changeit"
+                    "value": "-Djavax.net.ssl.trustStore=/etc/cabundle/test-truststore.p12 -Djavax.net.ssl.trustStorePassword= -Djavax.net.ssl.trustStoreType=PKCS12"
                   }
                 ]
               }
@@ -111,8 +111,8 @@
                   "name": "test-tls-cm",
                   "items": [
                     {
-                      "key": "test-tls-key",
-                      "path": "truststore.jks"
+                      "key": "test-truststore.p12",
+                      "path": "test-truststore.p12"
                     }
                   ]
                 }

--- a/operator/controller/webhook/test/test_sync.py
+++ b/operator/controller/webhook/test/test_sync.py
@@ -4,8 +4,13 @@ from typing import Mapping
 
 import pytest
 
-from webhook.introute.sync import sync, VolumeConfig, _spring_cloud_k8s_config, SECRETS_ROOT, \
-    _new_deployment
+from webhook.introute.sync import (
+    sync,
+    VolumeConfig,
+    _spring_cloud_k8s_config,
+    SECRETS_ROOT,
+    _new_deployment,
+)
 
 
 def test_empty_parent_raises_exception(full_route):
@@ -14,49 +19,50 @@ def test_empty_parent_raises_exception(full_route):
 
 
 def test_full_integration_route(full_route):
-    response = load_json('json/full-response.json')
+    response = load_json("json/full-response.json")
     actual = sync(full_route)
 
     assert response == actual
 
 
 def test_vol_config_missing_route_map_raise_exception(full_route):
-    del full_route['spec']['routeConfigMap']
+    del full_route["spec"]["routeConfigMap"]
     with pytest.raises(KeyError):
-        VolumeConfig(full_route['spec'])
+        VolumeConfig(full_route["spec"])
 
 
-def test_vol_config_missing_secrets_and_pvcs(full_route):
-    del full_route['spec']['secretSources']
-    del full_route['spec']['persistentVolumeClaims']
-    vol_conf = VolumeConfig(full_route['spec'])
+def test_vol_config_missing_secrets_and_pvcs_no_fail(full_route):
+    del full_route["spec"]["secretSources"]
+    del full_route["spec"]["persistentVolumeClaims"]
+    vol_conf = VolumeConfig(full_route["spec"])
 
-    route_vol = {'name': 'integration-route-config', 'configMap': {'name': 'testroute-xml'}}
-    route_mnt = {'name': 'integration-route-config', 'mountPath': '/var/spring/xml'}
-
-    assert vol_conf.get_volumes() == [route_vol]
-    assert vol_conf.get_mounts() == [route_mnt]
+    assert len(vol_conf.get_volumes()) > 0
+    assert len(vol_conf.get_mounts()) > 0
 
 
 def test_spring_app_config_json_missing_props_sources(full_route):
-    del full_route['spec']['propSources']
+    del full_route["spec"]["propSources"]
 
-    spring_conf = _spring_cloud_k8s_config(full_route)
+    spring_conf_env_var = _spring_cloud_k8s_config(full_route)
+    spring_conf = json.loads(spring_conf_env_var["value"])
 
-    assert spring_conf['spring']['cloud']['kubernetes']['secrets'] == {'paths': SECRETS_ROOT}
+    assert spring_conf["spring"]["cloud"]["kubernetes"]["secrets"] == {
+        "paths": SECRETS_ROOT
+    }
 
 
 def test_spring_app_config_json_missing_secret_sources(full_route):
-    del full_route['spec']['secretSources']
+    del full_route["spec"]["secretSources"]
 
-    spring_conf = _spring_cloud_k8s_config(full_route)
+    spring_conf_env_var = _spring_cloud_k8s_config(full_route)
+    spring_conf = json.loads(spring_conf_env_var["value"])
 
-    assert spring_conf['spring']['cloud']['kubernetes']['config']['sources'] is not None
+    assert spring_conf["spring"]["cloud"]["kubernetes"]["config"]["sources"] is not None
 
 
 def test_spring_app_config_json_missing_props_and_secret_sources(full_route):
-    del full_route['spec']['propSources']
-    del full_route['spec']['secretSources']
+    del full_route["spec"]["propSources"]
+    del full_route["spec"]["secretSources"]
 
     spring_conf = _spring_cloud_k8s_config(full_route)
 
@@ -64,62 +70,93 @@ def test_spring_app_config_json_missing_props_and_secret_sources(full_route):
 
 
 def test_pod_template_no_annotations(full_route):
-    del full_route['spec']['annotations']
+    del full_route["spec"]["annotations"]
 
     deployment = _new_deployment(full_route)
 
-    pod_template = deployment['spec']['template']
-    assert pod_template['metadata'].get('annotations') is None
+    pod_template = deployment["spec"]["template"]
+    assert pod_template["metadata"].get("annotations") is None
 
 
 def test_pod_template_empty_annotations(full_route):
-    full_route['spec']['annotations'] = {}
+    full_route["spec"]["annotations"] = {}
 
     deployment = _new_deployment(full_route)
 
-    pod_template = deployment['spec']['template']
-    assert pod_template['metadata'].get('annotations') is None
+    pod_template = deployment["spec"]["template"]
+    assert pod_template["metadata"].get("annotations") is None
 
 
 def test_pod_template_no_props_and_secrets_spring_config_not_present(full_route):
-    del full_route['spec']['propSources']
-    del full_route['spec']['secretSources']
+    del full_route["spec"]["propSources"]
+    del full_route["spec"]["secretSources"]
 
     deployment = _new_deployment(full_route)
 
-    pod_template = deployment['spec']['template']
-    container = pod_template['spec']['containers'][0]
-    assert container.get('env') is None
+    check_env_var_absent(deployment, "SPRING_APPLICATION_JSON")
+
+
+def test_pod_template_no_tls(full_route):
+    del full_route["spec"]["tls"]
+
+    deployment = _new_deployment(full_route)
+
+    check_env_var_absent(deployment, "JDK_JAVA_OPTIONS")
+    check_volume_absent(deployment, "truststore")
+    check_volume_mounts_absent(deployment, "truststore")
 
 
 def test_deployment_missing_labels(full_route):
-    del full_route['spec']['labels']
+    del full_route["spec"]["labels"]
 
     deployment = _new_deployment(full_route)
 
-    labels = deployment['metadata']['labels']
+    labels = deployment["metadata"]["labels"]
     assert len(labels) > 0
 
 
 def test_deployment_empty_labels(full_route):
-    full_route['spec']['labels'] = {}
+    full_route["spec"]["labels"] = {}
 
     deployment = _new_deployment(full_route)
 
-    labels = deployment['metadata']['labels']
+    labels = deployment["metadata"]["labels"]
     assert len(labels) > 0
 
 
 @pytest.fixture()
 def full_route(full_route_load: dict):
-    return copy.deepcopy(full_route_load['parent'])
+    return copy.deepcopy(full_route_load["parent"])
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def full_route_load() -> Mapping:
-    return load_json('json/full-iroute-request.json')
+    return load_json("json/full-iroute-request.json")
 
 
 def load_json(filepath: str) -> Mapping:
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         return json.load(f)
+
+
+def check_env_var_absent(deployment: Mapping, name: str):
+    container = get_container(deployment)
+    env_var_names = [env_var["name"] for env_var in container.get("env")]
+    assert name not in env_var_names
+
+
+def check_volume_absent(deployment: Mapping, name: str):
+    vols = deployment["spec"]["template"]["spec"]["volumes"]
+    vol_names = [v["name"] for v in vols]
+    assert name not in vol_names
+
+
+def check_volume_mounts_absent(deployment: Mapping, name: str):
+    mounts = get_container(deployment)["volumeMounts"]
+    mnt_names = [m["name"] for m in mounts]
+    assert name not in mnt_names
+
+
+def get_container(deployment: Mapping) -> Mapping:
+    pod_template = deployment["spec"]["template"]
+    return pod_template["spec"]["containers"][0]

--- a/operator/crd/v1alpha1/crd.yaml
+++ b/operator/crd/v1alpha1/crd.yaml
@@ -78,9 +78,20 @@ spec:
                     required:
                       - claimName
                       - mountPath
+                tls:
+                  description: "Configure TLS connections using a JKS truststore. The truststore should have the password set to 'changeit'"
+                  type: object
+                  properties:
+                    configMapName:
+                      type: string
+                    key:
+                      type: string
+                      default: truststore.jks
+                  required:
+                    - configMapName
               required:
                 - routeConfigMap
           required:
             - spec
       subresources: # Can be used to add status information to CustomResource objects
-        status: {}
+        status: { }

--- a/operator/crd/v1alpha1/crd.yaml
+++ b/operator/crd/v1alpha1/crd.yaml
@@ -79,16 +79,22 @@ spec:
                       - claimName
                       - mountPath
                 tls:
-                  description: "Configure TLS connections using a JKS truststore. The truststore should have the password set to 'changeit'"
+                  description: "Configure client TLS connections using a JKS or PKCS12 truststore. A JKS truststore should have its password set to 'changeit', while a PKCS12 truststore should have an empty password."
                   type: object
                   properties:
                     configMapName:
                       type: string
                     key:
                       type: string
-                      default: truststore.jks
+                    type:
+                      type: string
+                      enum:
+                        - jks
+                        - pkcs12
                   required:
                     - configMapName
+                    - key
+                    - type
               required:
                 - routeConfigMap
           required:


### PR DESCRIPTION
Adds IntegrationRoute support for a TLS truststore. 

Example:
```yaml
apiVersion: keip.octo.com/v1alpha1
kind: IntegrationRoute
metadata:
  name: testroute
spec:
  routeConfigMap: testroute-xml
  propSources:
    - name: testroute-props
  secretSources:
    - testroute-secret
  tls:
    configMapName: trust-bundle-cm  # configmap with the required truststore file
    key: bundle-key  # configmap key that maps to a truststore.jks or truststore.p12 file
    type: "pkcs12"  # or "jks"
```

When adding the `tls` spec to the CRD, the Keip controller will handle mounting the truststore file as well as configuring the Java application (via the `JDK_JAVA_OPTIONS` env var) to use the truststore.

The PR [takes a page from trust-manager's approach to passwords](https://cert-manager.io/docs/trust/trust-manager/#targets) - since the truststore won't contain any private keys, Keip assumes the truststore password will always be set to `changeit` for JKS truststores, while PKCS12 truststores should have an empty password..