### PR TITLE
Add unit test coverage reporting for integration-route controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ build/
 __pycache__/
 *.py[cod]
 *$py.class
+.test_coverage/

--- a/operator/controller/webhook/Makefile
+++ b/operator/controller/webhook/Makefile
@@ -5,6 +5,8 @@ IMG_REGISTRY := ghcr.io/octoconsulting
 IMG_NAME := integration-route-lambda-controller
 CONTAINER_NAME := integration-route-webhook
 PYTHON := python3
+TEST_COVERAGE_DIR := .test_coverage
+TEST_COVERAGE_FILE := $(TEST_COVERAGE_DIR)/.coverage
 
 .PHONY: start-dev
 start-dev-server:
@@ -12,7 +14,15 @@ start-dev-server:
 
 .PHONY: test
 test:
-	cd test && pytest
+	cd test && mkdir -p $(TEST_COVERAGE_DIR) && coverage run --data-file=$(TEST_COVERAGE_FILE) -m pytest
+
+.PHONY: report-test-coverage
+report-test-coverage: test
+	cd test && coverage report --data-file $(TEST_COVERAGE_FILE)
+
+.PHONY: report-test-coverage-html
+report-test-coverage-html: test
+	cd test && coverage html --data-file $(TEST_COVERAGE_FILE) --directory $(TEST_COVERAGE_DIR)/html && open $(TEST_COVERAGE_DIR)/html/index.html
 
 .PHONY: deploy
 deploy: build

--- a/operator/controller/webhook/dev-requirements.txt
+++ b/operator/controller/webhook/dev-requirements.txt
@@ -1,3 +1,4 @@
 mypy
 pytest
 httpx
+coverage


### PR DESCRIPTION
Updates the integration-route controller Makefile to use the [Coverage.py](https://coverage.readthedocs.io/en/7.4.0/) tool to generate unit test coverage reports.