### PR TITLE
Update the sync endpoint to add the Integration Route annotations to deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ __pycache__/
 *.py[cod]
 *$py.class
 .test_coverage/
+**pytest_cache
+**.venv

--- a/operator/controller/integrationroute-controller.yaml
+++ b/operator/controller/integrationroute-controller.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: ghcr.io/octoconsulting/integration-route-lambda-controller:0.3.0
+          image: ghcr.io/octoconsulting/integration-route-lambda-controller:0.4.0
           ports:
             - containerPort: 7080
               name: webhook-http

--- a/operator/controller/webhook/Makefile
+++ b/operator/controller/webhook/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.3.0
+VERSION ?= 0.4.0
 HOST_PORT ?= 7080
 
 IMG_REGISTRY := ghcr.io/octoconsulting

--- a/operator/controller/webhook/introute/sync.py
+++ b/operator/controller/webhook/introute/sync.py
@@ -236,6 +236,7 @@ def _new_deployment(parent):
         "metadata": {
             "name": parent_metadata["name"],
             "labels": labels,
+            "annotations": parent["spec"].get("annotations", {})
         },
         "spec": {
             "selector": {

--- a/operator/controller/webhook/test/json/full-response.json
+++ b/operator/controller/webhook/test/json/full-response.json
@@ -12,6 +12,9 @@
           "app.kubernetes.io/instance": "integrationroute-testroute",
           "app.kubernetes.io/version": "latest",
           "firstKey": "firstValue"
+        },
+        "annotations": {
+          "aKey1": "aValue1"
         }
       },
       "spec": {

--- a/operator/controller/webhook/test/test_sync.py
+++ b/operator/controller/webhook/test/test_sync.py
@@ -149,6 +149,26 @@ def test_deployment_empty_labels(full_route):
     assert len(labels) > 0
 
 
+def test_deployment_missing_annotations(full_route):
+    del full_route["spec"]["annotations"]
+
+    deployment = _new_deployment(full_route)
+
+    assert "annotations" in deployment["metadata"]
+    annotations = deployment["metadata"]["annotations"]
+    assert len(annotations) == 0
+
+
+def test_deployment_empty_annotations(full_route):
+    full_route["spec"]["annotations"] = {}
+
+    deployment = _new_deployment(full_route)
+
+    assert "annotations" in deployment["metadata"]
+    annotations = deployment["metadata"]["annotations"]
+    assert len(annotations) == 0
+
+
 @pytest.fixture()
 def full_route(full_route_load: dict):
     return copy.deepcopy(full_route_load["parent"])

--- a/operator/crd/v1alpha1/crd.yaml
+++ b/operator/crd/v1alpha1/crd.yaml
@@ -23,12 +23,12 @@ spec:
               type: object
               properties:
                 annotations:
-                  description: "Annotations to add to the IntegrationRoute pod template"
+                  description: "Annotations to add to the IntegrationRoute pod and deployment templates"
                   type: object
                   additionalProperties:
                     type: string
                 labels:
-                  description: "Labels to add to the IntegrationRoute pod template"
+                  description: "Labels to add to the IntegrationRoute pod and deployment templates"
                   type: object
                   additionalProperties:
                     type: string


### PR DESCRIPTION
# About
This change adds the annotations in the parent Integration Route to the child deployment as well as the pod.

Unit tests should be enough to confirm this change.