### PR TITLE
Add startupProbe to containers created by the operator

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.3.0
+VERSION ?= 0.3.1
 KEIP_INTEGRATION_IMAGE ?= ghcr.io/octoconsulting/keip/minimal-app:0.0.2
 
 KUBECTL := kubectl

--- a/operator/controller/integrationroute-controller.yaml
+++ b/operator/controller/integrationroute-controller.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: ghcr.io/octoconsulting/keip/route-webhook:0.6.0
+          image: ghcr.io/octoconsulting/keip/route-webhook:0.6.1
           ports:
             - containerPort: 7080
               name: webhook-http

--- a/operator/example/README.md
+++ b/operator/example/README.md
@@ -8,21 +8,12 @@ Prerequisites:
 - Metacontroller
 - Keip CRDs and controller
 - Access to a `keip-integration` image
-- Cert-Manager
 
-Running the example:
-1. Install Cert-Manager:
-```shell
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml
-```
-2. Create JKS password secret:
-```shell
-kubectl create secret generic --from-literal=password=password jks-password
-```
-3. Run example:
+Run the example:
 ```shell
 kubectl apply -k example
 ```
+*_Note_*: The example uses a keystore.jks file and a certificate created by [Cert Manager](https://cert-manager.io/).
 
 This should result in the creation of the following resources:
 
@@ -44,6 +35,7 @@ kubectl get pod
 NAME                         READY   STATUS    RESTARTS   AGE
 testroute-74d574bf85-tbv9m   1/1     Running   0          99s
 ```
+*_Note_*: Cert Manager takes a few seconds to create the certificate and keystore secret. The testroute pod will not start until the keystore.jks secret is available to mount.
 
 Check the pod's logs for the configured greeting and secret:
 ```shell

--- a/operator/example/kustomization.yaml
+++ b/operator/example/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - https://github.com/cert-manager/cert-manager/releases/download/v1.15.2/cert-manager.yaml
   - testroute.yaml
   - cert.yaml
 
@@ -19,3 +20,6 @@ secretGenerator:
   - name: testroute-secret
     literals:
       - test.secret=pass123
+  - name: jks-password
+    literals:
+      - password=password

--- a/operator/webhook/.dockerignore
+++ b/operator/webhook/.dockerignore
@@ -11,5 +11,6 @@ pip-log.txt
 .pytest_cache
 
 # Local directives
+.venv
 test
 requirements-dev.txt

--- a/operator/webhook/Makefile
+++ b/operator/webhook/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.6.0
+VERSION ?= 0.6.1
 HOST_PORT ?= 7080
 
 IMG_REGISTRY := ghcr.io/octoconsulting

--- a/operator/webhook/introute/sync.py
+++ b/operator/webhook/introute/sync.py
@@ -291,7 +291,8 @@ def _create_pod_template(parent, labels, integration_image):
                             "port": management_port,
                             "scheme": scheme
                         },
-                        "initialDelaySeconds": 10,
+                        "failureThreshold": 3,
+                        "timeoutSeconds": 3
                     },
                     "readinessProbe": {
                         "httpGet": {
@@ -299,7 +300,17 @@ def _create_pod_template(parent, labels, integration_image):
                             "port": management_port,
                             "scheme": scheme
                         },
-                        "initialDelaySeconds": 10,
+                        "failureThreshold": 2,
+                        "timeoutSeconds": 3
+                    },
+                    "startupProbe": {
+                        "httpGet": {
+                            "path": "/actuator/health/liveness",
+                            "port": management_port,
+                            "scheme": scheme
+                        },
+                        "failureThreshold": 12,
+                        "timeoutSeconds": 3
                     },
                 },
             ],

--- a/operator/webhook/test/json/full-response.json
+++ b/operator/webhook/test/json/full-response.json
@@ -82,7 +82,8 @@
                     "port": 8443,
                     "scheme": "HTTPS"
                   },
-                  "initialDelaySeconds": 10
+                  "failureThreshold": 3,
+                  "timeoutSeconds": 3
                 },
                 "readinessProbe": {
                   "httpGet": {
@@ -90,7 +91,17 @@
                     "port": 8443,
                     "scheme": "HTTPS"
                   },
-                  "initialDelaySeconds": 10
+                  "failureThreshold": 2,
+                  "timeoutSeconds": 3
+                },
+                "startupProbe": {
+                  "httpGet": {
+                    "path": "/actuator/health/liveness",
+                    "port": 8443,
+                    "scheme": "HTTPS"
+                  },
+                  "failureThreshold": 12,
+                  "timeoutSeconds": 3
                 },
                 "env": [
                   {


### PR DESCRIPTION
## About
Prior to this change, a container created by the KEIP operator only had 40 seconds to become healthy before being killed. In some scenarios where many routes are deployed this resulted in container boot-looping. To fix this each container is now configured to use a startupProbe to give the container up to 120 seconds to registry as healthy before the liveness and readiness probes to take over.

## Hero Instructions
1. Start with a fresh Minikube cluster or equivalent
2. From the `operator/webhook` directory: `make build && minikube image load ghcr.io/octoconsulting/keip/route-webhook:0.6.1`
3. In the operator directory, run `make all` to deploy the integration route controller.
4. Deploy the example route: `kubectl apply -k operator/example`
5. Port forward the pod and verify it can be hit in the browser: `kubectl port-forward testroute-74d574bf85-tbv9m 8443:8443`
6. Verify the pod has a startupProbe configured: `kubectl describe <pod>`