### PR TITLE
only run verify-versions on PRs

### DIFF
--- a/.github/workflows/minimal-app.yml
+++ b/.github/workflows/minimal-app.yml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   verify-versions:
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +45,6 @@ jobs:
 
   release:
     if: github.ref == 'refs/heads/main'
-    needs: verify-versions
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   verify-versions:
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +39,6 @@ jobs:
 
   release:
     if: github.ref == 'refs/heads/main'
-    needs: verify-versions
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/webhook.yml
+++ b/.github/workflows/webhook.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   verify-versions:
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +56,7 @@ jobs:
           push: false
 
   release:
-    needs: [test, verify-versions]
+    needs: test
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
Only run verify-versions on PRs because builds on main do not expose the environment variable GITHUB_BASE_REF. We dont need to verify releasable on main because checks are already done in PRs.