### PR TITLE
Add pod container resource limits and requests

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.4.2
+VERSION ?= 0.5.0
 GIT_TAG := operator_v$(VERSION)
 KEIP_INTEGRATION_IMAGE ?= ghcr.io/octoconsulting/keip/minimal-app:latest
 

--- a/operator/controller/integrationroute-controller.yaml
+++ b/operator/controller/integrationroute-controller.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: ghcr.io/octoconsulting/keip/route-webhook:0.8.1
+          image: ghcr.io/octoconsulting/keip/route-webhook:0.9.0
           ports:
             - containerPort: 7080
               name: webhook-http

--- a/operator/crd/crd.yaml
+++ b/operator/crd/crd.yaml
@@ -110,7 +110,7 @@ spec:
                   type: object
                   properties:
                     limits:
-                      description: "Limits describes the maximum amount of compute resources allowed."
+                      description: "Limits describe the maximum amount of compute and memory resources allowed."
                       type: object
                       properties:
                         cpu:
@@ -118,7 +118,7 @@ spec:
                         memory:
                           type: string
                     requests:
-                      description: "Requests describes the minimum amount of CPU resources required."
+                      description: "Requests describe the minimum amount of compute and memory resources required."
                       type: object
                       properties:
                         cpu:

--- a/operator/crd/crd.yaml
+++ b/operator/crd/crd.yaml
@@ -105,6 +105,28 @@ spec:
                       - properties:
                         required:
                           - secretRef
+                resources:
+                  description: "Compute resources given to the route containers. Follows https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container"
+                  type: object
+                  properties:
+                    limits:
+                      description: "Limits describes the maximum amount of compute resources allowed."
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                    requests:
+                      description: "Requests describes the minimum amount of CPU resources required."
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      
+
                 replicas: # not yet implemented
                   description: "Number of containers running the integration route"
                   type: integer

--- a/operator/webhook/Dockerfile
+++ b/operator/webhook/Dockerfile
@@ -9,4 +9,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD python -m uvicorn --host 0.0.0.0 --port 7080 --app-dir /code app:app
+ENTRYPOINT ["python", "-m", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "7080", "--app-dir", "/code"]

--- a/operator/webhook/Makefile
+++ b/operator/webhook/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.8.1
+VERSION ?= 0.9.0
 HOST_PORT ?= 7080
 GIT_TAG := webhook_v$(VERSION)
 

--- a/operator/webhook/test/json/full-iroute-request.json
+++ b/operator/webhook/test/json/full-iroute-request.json
@@ -87,11 +87,11 @@
       ],
       "resources": {
         "limits": {
-          "memory": "2Gi"
+          "memory": "5Gi"
         },
         "requests": {
-          "cpu": "500m",
-          "memory": "1Gi"
+          "cpu": "1",
+          "memory": "2Gi"
         }
       }
     }

--- a/operator/webhook/test/json/full-iroute-request.json
+++ b/operator/webhook/test/json/full-iroute-request.json
@@ -84,7 +84,16 @@
           "name": "test-cm-2",
           "mountPath": "/path/to/cm2"
         }
-      ]
+      ],
+      "resources": {
+        "limits": {
+          "memory": "2Gi"
+        },
+        "requests": {
+          "cpu": "500m",
+          "memory": "1Gi"
+        }
+      }
     }
   }
 }

--- a/operator/webhook/test/json/full-response.json
+++ b/operator/webhook/test/json/full-response.json
@@ -145,7 +145,16 @@
                       "name": "my-secret"
                     }
                   }
-                ]
+                ],
+                "resources": {
+                  "requests": {
+                    "cpu": "500m",
+                    "memory": "1Gi"
+                  },
+                  "limits": {
+                    "memory": "2Gi"
+                  }
+                }
               }
             ],
             "volumes": [

--- a/operator/webhook/test/json/full-response.json
+++ b/operator/webhook/test/json/full-response.json
@@ -148,11 +148,11 @@
                 ],
                 "resources": {
                   "requests": {
-                    "cpu": "500m",
-                    "memory": "1Gi"
+                    "cpu": "1",
+                    "memory": "2Gi"
                   },
                   "limits": {
-                    "memory": "2Gi"
+                    "memory": "5Gi"
                   }
                 }
               }

--- a/operator/webhook/test/test_sync.py
+++ b/operator/webhook/test/test_sync.py
@@ -289,7 +289,7 @@ def test_pod_resources_limits_only(full_route):
 
     pod_resources = pod["spec"]["containers"][0]["resources"]
     assert "requests" not in pod_resources
-    assert "memory" in pod_resources["limits"]
+    assert pod_resources["limits"].get("memory") == "5Gi"
 
 
 def test_pod_resources_requests_only(full_route):
@@ -299,8 +299,8 @@ def test_pod_resources_requests_only(full_route):
 
     pod_resources = pod["spec"]["containers"][0]["resources"]
     assert "limits" not in pod_resources
-    assert "cpu" in pod_resources["requests"]
-    assert "memory" in pod_resources["requests"]
+    assert pod_resources["requests"].get("cpu") == "1"
+    assert pod_resources["requests"].get("memory") == "2Gi"
 
 
 @pytest.fixture()


### PR DESCRIPTION
# About
This updates the Integration Route CRD to include a fields for setting limits and requests for CPU and Memory resources inside of the route container. Requests help the kube scheduler determine which nodes are available to host routes and spread load throughout the cluster. Limits will prevent route containers from causing resource starvation issues on the host.

If an Integration route does not include a `resources` field, then the following defaults will be used:

```json
{
  "requests": {
    "cpu": "500m",
    "memory": "1Gi"
  },
  "limits": {
    "memory": "2Gi"
  }
}
```