### PR TITLE
Fix KeyError in webhook when parent status is missing from request

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.12.0
+VERSION ?= 0.12.1
 GIT_TAG := operator_v$(VERSION)
 KEIP_INTEGRATION_IMAGE ?= ghcr.io/octoconsulting/keip/minimal-app:latest
 

--- a/operator/controller/core-controller.yaml
+++ b/operator/controller/core-controller.yaml
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: ghcr.io/octoconsulting/keip/route-webhook:0.14.0
+          image: ghcr.io/octoconsulting/keip/route-webhook:0.14.1
           ports:
             - containerPort: 7080
               name: webhook-http

--- a/operator/webhook/Makefile
+++ b/operator/webhook/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.14.0
+VERSION ?= 0.14.1
 HOST_PORT ?= 7080
 GIT_TAG := webhook_v$(VERSION)
 

--- a/operator/webhook/core/sync.py
+++ b/operator/webhook/core/sync.py
@@ -475,7 +475,7 @@ def _compute_status(parent: Mapping, children: Mapping) -> Mapping:
 
     ready_conditions = [
         _get_status_ready_condition(
-            parent["status"], expected_replicas == ready_replicas
+            parent.get("status", {}), expected_replicas == ready_replicas
         )
     ]
 

--- a/operator/webhook/core/test/test_status.py
+++ b/operator/webhook/core/test/test_status.py
@@ -107,6 +107,18 @@ def test_status_with_child_deployment_missing_ready_replicas_field_default_to_un
     assert status["readyReplicas"] == 0
 
 
+def test_status_conditions_with_parent_missing_status_field_generate_new_status(
+    patch_datetime, full_route
+):
+    del full_route["parent"]["status"]
+
+    status = _compute_status(full_route["parent"], full_route["children"])
+
+    conditions = status["conditions"]
+    assert len(conditions) == 2
+    assert conditions[1] == STATUS_READY_CONDITION
+
+
 def test_ready_status_with_parent_missing_status_field_generate_new_status(
     patch_datetime,
 ):


### PR DESCRIPTION
When generating a deployed IntegrationRoute's status, the webhook assumes the parent resource always has a `status` field defined. However, this is not always the case, in fact when the metacontroller reconciliation loop is triggered for a new IntegrationRoute, it regularly sends requests where the parent is missing its `status` field. 

This turns out to be harmless, as subsequent requests have the `status` field populated and the metacontroller is able to reconcile the route correctly. Nonetheless, it is preferable to avoid the spurious error logs in the webhook and metacontroller.