### PR TITLE
feat: support per-route container image override

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.17.0
+VERSION ?= 0.18.0
 GIT_TAG := operator_v$(VERSION)
 
 KUBECTL := kubectl

--- a/operator/controller/webhook-deployment.yaml
+++ b/operator/controller/webhook-deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: webhook
-          image: ghcr.io/codice/keip/webapp:0.20.0
+          image: ghcr.io/codice/keip/webapp:0.21.0
           ports:
             - containerPort: 7080
               name: webhook-http

--- a/operator/crd/crd.yaml
+++ b/operator/crd/crd.yaml
@@ -51,6 +51,9 @@ spec:
                   type: object
                   additionalProperties:
                     type: string
+                image:
+                  description: "Container image to use for this IntegrationRoute. Overrides the cluster-wide default integration image set in the controller configuration."
+                  type: string
                 routeConfigMap:
                   description: "Name of a ConfigMap containing integration route definitions. The ConfigMap should be in the same namespace as the IntegrationRoute resource"
                   type: string

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.20.0
+VERSION ?= 0.21.0
 HOST_PORT ?= 7080
 GIT_TAG := webapp_v$(VERSION)
 

--- a/webapp/core/sync.py
+++ b/webapp/core/sync.py
@@ -432,7 +432,7 @@ def _new_deployment(parent):
             },
             "replicas": parent["spec"]["replicas"],
             "template": _create_pod_template(
-                parent, labels, cfg.INTEGRATION_CONTAINER_IMAGE
+                parent, labels, parent["spec"].get("image", cfg.INTEGRATION_CONTAINER_IMAGE)
             ),
         },
     }


### PR DESCRIPTION
## Summary

Adds an optional `spec.image` field to the IntegrationRoute CRD, allowing individual routes to specify their own container image instead of using the cluster-wide default.

## Motivation

Currently, all IntegrationRoutes in a keip cluster share the same container image defined in `keip-controller-props`. This means if you have multiple applications with different classpaths (e.g., different custom beans or dependencies), you must either:

1. Bundle everything into a single fat image
2. Run separate keip clusters

Neither is ideal. Per-route images let different applications coexist naturally in the same cluster.

## Changes

- **CRD** (`operator/crd/crd.yaml`): Added `spec.image` (optional string) to v1alpha2 schema
- **Webhook** (`webapp/core/sync.py`): Resolve image from `spec.image` with fallback to global `INTEGRATION_CONTAINER_IMAGE`
- **Tests** (`webapp/core/test/test_sync.py`): Two new tests verifying override and default fallback

## Usage

```yaml
apiVersion: keip.codice.org/v1alpha2
kind: IntegrationRoute
metadata:
  name: my-custom-route
spec:
  image: "registry.example.com/my-app:1.0"
  routeConfigMap: my-route-xml
  replicas: 1
```

When `spec.image` is omitted, behavior is unchanged — the global default from the controller ConfigMap is used.

## Backward Compatibility

Fully backward compatible. The field is optional with no default in the CRD schema. Existing IntegrationRoutes without `spec.image` continue to work exactly as before.